### PR TITLE
Add ACQuire subsystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ The software does insert some sleep time on specific commands (such as reset and
 | Command Category | Coverage |
 | --- | --- |
 | AUToscale, etc. | YES |
-| ACQuire | no |
+| ACQuire | YES |
 | CALibrate | no |
 | CHANnel | YES |
 | CURSor | no |

--- a/docs/source/acquire.rst
+++ b/docs/source/acquire.rst
@@ -1,0 +1,5 @@
+Acquire
+=======
+
+.. automodule:: src.acquire
+	:members: acquire

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -13,6 +13,7 @@ Click the links below or in the sidebar to see how the available functional inte
    channel.rst
    timebase.rst
    trigger.rst
+   acquire.rst
    display.rst
    waveform.rst
    ieee.rst

--- a/rigol_ds1000z/src/acquire.py
+++ b/rigol_ds1000z/src/acquire.py
@@ -1,0 +1,44 @@
+from collections import namedtuple
+from typing import Optional, Union
+
+ACQUIRE = namedtuple("ACQUIRE", "averages memdepth srate type")
+
+
+def acquire(
+    oscope,
+    averages: Optional[int] = None,
+    memdepth: Union[int, str, None] = None,
+    type: Optional[str] = None,
+):
+    """
+    Send commands to control an oscilloscope's acquisition behavior.
+    All arguments are optional. ``averages`` only takes effect while the
+    acquisition ``type`` is ``AVERages``; when both are specified the
+    ``type`` command is issued first.
+
+    Args:
+        averages (int): ``:ACQuire:AVERages`` (a power of two, 2 to 1024).
+        memdepth (int, str): ``:ACQuire:MDEPth`` (an integer point count or ``AUTO``).
+        type (str): ``:ACQuire:TYPE`` (``NORM``, ``AVER``, ``PEAK``, or ``HRES``).
+
+    Returns:
+        A namedtuple with fields corresponding to the named arguments of this function.
+        All fields are queried regardless of which arguments were initially provided.
+        The ``srate`` field is additionally provided as a result of the
+        query ``:ACQuire:SRATe?`` (the sample rate in samples per second).
+    """
+    if type is not None:
+        oscope.write(":ACQ:TYPE {:s}".format(type))
+
+    if averages is not None:
+        oscope.write(":ACQ:AVER {:d}".format(averages))
+
+    if memdepth is not None:
+        oscope.write(":ACQ:MDEP {}".format(memdepth))
+
+    return ACQUIRE(
+        averages=int(oscope.query(":ACQ:AVER?")),
+        memdepth=oscope.query(":ACQ:MDEP?"),
+        srate=float(oscope.query(":ACQ:SRAT?")),
+        type=oscope.query(":ACQ:TYPE?"),
+    )

--- a/rigol_ds1000z/src/oscope.py
+++ b/rigol_ds1000z/src/oscope.py
@@ -4,6 +4,7 @@ from typing import Optional
 
 from pyvisa import ResourceManager
 
+from rigol_ds1000z.src.acquire import acquire
 from rigol_ds1000z.src.channel import channel
 from rigol_ds1000z.src.display import display
 from rigol_ds1000z.src.ieee import ieee
@@ -17,8 +18,8 @@ class Rigol_DS1000Z:
     """
     A class for communicating with a Rigol DS1000Z series oscilloscope.
     This class is compatible with context managers. The functional interfaces
-    ``ieee``, ``channel``, ``timebase``, ``display``, ``waveform``, and ``trigger``
-    are bound to this object as partial functions.
+    ``ieee``, ``channel``, ``timebase``, ``display``, ``waveform``, ``trigger``,
+    and ``acquire`` are bound to this object as partial functions.
 
     Args:
         visa (str): The VISA resource address string.
@@ -41,6 +42,7 @@ class Rigol_DS1000Z:
         self.display = partial(display, self)
         self.waveform = partial(waveform, self)
         self.trigger = partial(trigger, self)
+        self.acquire = partial(acquire, self)
 
     def __enter__(self):
         return self.open()

--- a/tests/test_acquire.py
+++ b/tests/test_acquire.py
@@ -1,0 +1,30 @@
+from pytest import fixture
+
+from rigol_ds1000z import Rigol_DS1000Z
+
+
+@fixture(scope="function")
+def oscope():
+    with Rigol_DS1000Z() as oscope:
+        oscope.ieee(rst=True)
+        yield oscope
+
+
+def test_type(oscope):
+    for type in ["NORM", "AVER", "PEAK", "HRES"]:
+        assert oscope.acquire(type=type).type == type
+
+
+def test_averages(oscope):
+    acquire = oscope.acquire(type="AVER", averages=8)
+    assert acquire.type == "AVER"
+    assert acquire.averages == 8
+    assert oscope.acquire(averages=16).averages == 16
+
+
+def test_memdepth(oscope):
+    assert oscope.acquire(memdepth="AUTO").memdepth == "AUTO"
+
+
+def test_srate(oscope):
+    assert oscope.acquire().srate > 0


### PR DESCRIPTION
## Summary

Adds the **ACQuire** subsystem (`:ACQuire`), following the existing functional + namedtuple convention used by the other subsystems.

`acquire(averages, memdepth, type)` with set-if-given / always-read-back semantics:
- `type` → `:ACQuire:TYPE` (`NORM`, `AVER`, `PEAK`, `HRES`).
- `averages` → `:ACQuire:AVERages` (a power of two, 2–1024). `type` is issued before `averages`, since `:ACQ:AVER` only applies in `AVER` mode.
- `memdepth` → `:ACQuire:MDEPth` (an integer point count or `AUTO`).
- read-only `srate` field via `:ACQuire:SRATe?` (samples per second).

Also: registers `acquire` as a partial on `Rigol_DS1000Z`, adds `docs/source/acquire.rst` to the toctree, and flips the README coverage table (ACQuire: no → YES).

## Testing

`tests/test_acquire.py` follows the existing live-device pattern (mirrors `test_timebase.py`). Verified on a **DS1104Z** (fw 00.04.05.SP2) — **4/4 passing**.

## Note

No TUI panel is included. Surfacing new subsystems in the Textual app needs a grid-layout redesign (the current grid is full), which is better reviewed as its own PR — deferred intentionally.
