### PR TITLE
Add PULSe and SLOPe trigger modes; fix edge source parsing

### DIFF
--- a/docs/source/trigger.rst
+++ b/docs/source/trigger.rst
@@ -2,4 +2,4 @@ Trigger
 =======
 
 .. automodule:: src.trigger
-	:members: trigger, trigger_edge
+	:members: trigger, trigger_edge, trigger_pulse, trigger_slope

--- a/rigol_ds1000z/src/trigger.py
+++ b/rigol_ds1000z/src/trigger.py
@@ -4,9 +4,25 @@ from typing import Optional, Union
 
 TRIGGER = namedtuple(
     "TRIGGER",
-    "status sweep noisereject mode holdoff coupling source slope level",
-    defaults=(None,) * 5,  # (status, sweep, noisereject, mode) are required
+    "status sweep noisereject mode holdoff coupling source slope level "
+    "when upper lower window alevel blevel time",
+    defaults=(None,) * 12,  # (status, sweep, noisereject, mode) are required
 )
+
+
+def _source_token(source):
+    """Format a channel source as either ``CHAN<n>`` (int) or a literal (str)."""
+    return source if isinstance(source, str) else "CHAN{:d}".format(source)
+
+
+def _source_value(query):
+    """Coerce a queried source into an int channel number or a literal string.
+
+    Any non-channel source (such as ``AC`` or ``EXT``) is returned verbatim
+    rather than being passed to ``int()``, which the original code would only
+    avoid for the literal ``AC``.
+    """
+    return int(query[-1]) if query.startswith("CHAN") else query
 
 
 def trigger(
@@ -19,27 +35,43 @@ def trigger(
     source: Union[int, str, None] = None,
     slope: Optional[str] = None,
     level: Optional[float] = None,
+    when: Optional[str] = None,
+    upper: Optional[float] = None,
+    lower: Optional[float] = None,
+    window: Optional[str] = None,
+    alevel: Optional[float] = None,
+    blevel: Optional[float] = None,
+    time: Optional[float] = None,
 ):
     """
     Send commands to control an oscilloscope's triggering behavior.
-    This interface is only partially implemented so as to support edge-triggering.
-    All arguments are optional. Depending on the triggering mode, only
-    the applicable arguments are utilized by the relevant helper function.
+    The ``EDGE``, ``PULSe``, and ``SLOPe`` trigger modes are supported.
+    All arguments are optional. Depending on the triggering mode, only the
+    applicable arguments are utilized by the relevant helper function.
 
     Args:
         sweep (str): ``:TRIGger:SWEep``
         noisereject (bool): ``:TRIGger:NREJect``
         mode (str): ``:TRIGger:MODE``
-        holdoff (float): See helper functions.
-        coupling (str): See helper functions.
+        holdoff (float): See ``trigger_edge``.
+        coupling (str): See ``trigger_edge``.
         source (int, str): See helper functions.
-        slope (str): See helper functions.
-        level (float): See helper functions.
+        slope (str): See ``trigger_edge``.
+        level (float): See ``trigger_edge``, ``trigger_pulse``.
+        when (str): See ``trigger_pulse``, ``trigger_slope``.
+        upper (float): See ``trigger_pulse``, ``trigger_slope``.
+        lower (float): See ``trigger_pulse``, ``trigger_slope``.
+        window (str): See ``trigger_slope``.
+        alevel (float): See ``trigger_slope``.
+        blevel (float): See ``trigger_slope``.
+        time (float): See ``trigger_slope``.
 
     Returns:
         A namedtuple with fields corresponding to the named arguments of this function.
-        All fields are queried regardless of which arguments were initially provided.
-        The ``status`` field is additionally provided as a result of the query ``:TRIGger:STATus?``.
+        All fields applicable to the active mode are queried regardless of which
+        arguments were initially provided; fields for other modes are ``None``.
+        The ``status`` field is additionally provided as a result of the query
+        ``:TRIGger:STATus?``.
     """
     if sweep is not None:
         oscope.write(":TRIG:SWE {:s}".format(sweep))
@@ -63,6 +95,23 @@ def trigger(
             oscope, trigger_query, holdoff, coupling, source, slope, level
         )
 
+    if trigger_query.mode == "PULS":
+        return trigger_pulse(oscope, trigger_query, source, when, level, upper, lower)
+
+    if trigger_query.mode == "SLOP":
+        return trigger_slope(
+            oscope,
+            trigger_query,
+            source,
+            when,
+            time,
+            upper,
+            lower,
+            window,
+            alevel,
+            blevel,
+        )
+
     return trigger_query
 
 
@@ -84,25 +133,115 @@ def trigger_edge(oscope, trigger_query, holdoff, coupling, source, slope, level)
         oscope.write(":TRIG:COUP {:s}".format(coupling))
 
     if source is not None:
-        if isinstance(source, str):
-            oscope.write(":TRIG:EDG:SOUR {:s}".format(source))
-        else:
-            oscope.write(":TRIG:EDG:SOUR CHAN{:d}".format(source))
+        oscope.write(":TRIG:EDG:SOUR " + _source_token(source))
 
     if slope is not None:
         oscope.write(":TRIG:EDG:SLOP {:s}".format(slope))
 
     if level is not None:
-        oscope.write("TRIG:EDG:LEV {:0.10f}".format(level))
-
-    source_query = oscope.query(":TRIG:EDG:SOUR?")
-    if not source_query == "AC":
-        source_query = int(source_query[-1])
+        oscope.write(":TRIG:EDG:LEV {:0.10f}".format(level))
 
     return trigger_query._replace(
         holdoff=float(oscope.query(":TRIG:HOLD?")),
         coupling=oscope.query(":TRIG:COUP?"),
-        source=source_query,
+        source=_source_value(oscope.query(":TRIG:EDG:SOUR?")),
         slope=oscope.query(":TRIG:EDG:SLOP?"),
         level=float(oscope.query(":TRIG:EDG:LEV?")),
+    )
+
+
+def trigger_pulse(oscope, trigger_query, source, when, level, upper, lower):
+    """
+    Helper function to configure pulse-width triggering, ``:TRIGger:MODE PULSe``.
+
+    Args:
+        source (int, str): ``:TRIGger:PULSe:SOURce``
+        when (str): ``:TRIGger:PULSe:WHEN`` (e.g. ``PGReater``, ``PLESs``, ``PGLess``).
+        level (float): ``:TRIGger:PULSe:LEVel``
+        upper (float): ``:TRIGger:PULSe:UWIDth``
+        lower (float): ``:TRIGger:PULSe:LWIDth``
+    """
+    if source is not None:
+        oscope.write(":TRIG:PULS:SOUR " + _source_token(source))
+
+    if when is not None:
+        oscope.write(":TRIG:PULS:WHEN {:s}".format(when))
+
+    if level is not None:
+        oscope.write(":TRIG:PULS:LEV {:0.10f}".format(level))
+
+    if upper is not None:
+        oscope.write(":TRIG:PULS:UWID {:0.10f}".format(upper))
+
+    if lower is not None:
+        oscope.write(":TRIG:PULS:LWID {:0.10f}".format(lower))
+
+    return trigger_query._replace(
+        source=_source_value(oscope.query(":TRIG:PULS:SOUR?")),
+        when=oscope.query(":TRIG:PULS:WHEN?"),
+        level=float(oscope.query(":TRIG:PULS:LEV?")),
+        upper=float(oscope.query(":TRIG:PULS:UWID?")),
+        lower=float(oscope.query(":TRIG:PULS:LWID?")),
+    )
+
+
+def trigger_slope(
+    oscope,
+    trigger_query,
+    source,
+    when,
+    time,
+    upper,
+    lower,
+    window,
+    alevel,
+    blevel,
+):
+    """
+    Helper function to configure slope (rise/fall time) triggering,
+    ``:TRIGger:MODE SLOPe``.
+
+    Args:
+        source (int, str): ``:TRIGger:SLOPe:SOURce``
+        when (str): ``:TRIGger:SLOPe:WHEN`` (e.g. ``PGReater``, ``PLESs``, ``PGLess``).
+        time (float): ``:TRIGger:SLOPe:TIME``
+        upper (float): ``:TRIGger:SLOPe:TUPPer``
+        lower (float): ``:TRIGger:SLOPe:TLOWer``
+        window (str): ``:TRIGger:SLOPe:WINDow`` (``TA``, ``TB``, or ``TAB``).
+        alevel (float): ``:TRIGger:SLOPe:ALEVel``
+        blevel (float): ``:TRIGger:SLOPe:BLEVel``
+    """
+    if source is not None:
+        oscope.write(":TRIG:SLOP:SOUR " + _source_token(source))
+
+    if when is not None:
+        oscope.write(":TRIG:SLOP:WHEN {:s}".format(when))
+
+    if time is not None:
+        oscope.write(":TRIG:SLOP:TIME {:0.10f}".format(time))
+
+    if upper is not None:
+        oscope.write(":TRIG:SLOP:TUPP {:0.10f}".format(upper))
+
+    if lower is not None:
+        oscope.write(":TRIG:SLOP:TLOW {:0.10f}".format(lower))
+
+    if window is not None:
+        oscope.write(":TRIG:SLOP:WIND {:s}".format(window))
+
+    if alevel is not None:
+        oscope.write(":TRIG:SLOP:ALEV {:0.10f}".format(alevel))
+
+    if blevel is not None:
+        oscope.write(":TRIG:SLOP:BLEV {:0.10f}".format(blevel))
+
+    return trigger_query._replace(
+        source=_source_value(oscope.query(":TRIG:SLOP:SOUR?")),
+        when=oscope.query(":TRIG:SLOP:WHEN?"),
+        time=float(oscope.query(":TRIG:SLOP:TIME?")),
+        upper=float(oscope.query(":TRIG:SLOP:TUPP?")),
+        lower=float(oscope.query(":TRIG:SLOP:TLOW?")),
+        window=oscope.query(":TRIG:SLOP:WIND?"),
+        alevel=float(oscope.query(":TRIG:SLOP:ALEV?")),
+        blevel=float(oscope.query(":TRIG:SLOP:BLEV?")),
     )

--- a/tests/test_trigger.py
+++ b/tests/test_trigger.py
@@ -41,3 +41,30 @@ def test_trigger_edge(oscope):
     assert trigger.source == 2
     assert trigger.slope == "NEG"
     assert trigger.level == 0.5
+
+
+def test_trigger_pulse(oscope):
+    oscope.autoscale()
+
+    trigger = oscope.trigger(mode="PULS", source=2, when="PGR", level=0.5, lower=1e-6)
+
+    assert trigger.mode == "PULS"
+    assert trigger.source == 2
+    assert trigger.when == "PGR"
+    assert trigger.level == 0.5
+    assert trigger.lower == approx(1e-6)
+
+
+def test_trigger_slope(oscope):
+    oscope.autoscale()
+
+    trigger = oscope.trigger(
+        mode="SLOP", source=2, when="PGR", lower=1e-6, alevel=1.0, blevel=0.0
+    )
+
+    assert trigger.mode == "SLOP"
+    assert trigger.source == 2
+    assert trigger.when == "PGR"
+    assert trigger.lower == approx(1e-6)
+    assert trigger.alevel == 1.0
+    assert trigger.blevel == 0.0


### PR DESCRIPTION
## Summary

Extends the **TRIGger** interface beyond `EDGE` to the **PULSe** and **SLOPe** sub-modes, dispatched from `trigger()` by the queried mode exactly like the existing `trigger_edge()` helper.

- `trigger_pulse`: `:TRIGger:PULSe` (`source`, `when`, `level`, `upper`/`lower` width).
- `trigger_slope`: `:TRIGger:SLOPe` (`source`, `when`, `time`, `tupper`/`tlower`, `window`, `alevel`/`blevel`).
- The `TRIGGER` namedtuple is extended with the new mode fields; existing fields and their order are preserved (so the TUI keeps working), and fields for inactive modes read back as `None`.

**Edge source-parsing fix:** the read-back path is factored into `_source_value()`, which returns any non-channel source (`AC`, `EXT`) verbatim instead of unconditionally calling `int()` on it — the original code only special-cased the literal `AC`, so any other non-channel source would raise `ValueError`. `_source_token()` mirrors this for writes, and both are reused across the edge/pulse/slope helpers.

Also updates `docs/source/trigger.rst` to expose the new helpers.

## Testing

`tests/test_trigger.py` follows the existing live-device pattern. Verified on a **DS1104Z** (fw 00.04.05.SP2) with CH2 on the 1 kHz calibrator — **5/5 passing**, including the pre-existing edge/sweep/noise-reject tests (no regression).

## Note

No TUI panel is included. Surfacing new subsystems in the Textual app needs a grid-layout redesign (the current grid is full), which is better reviewed as its own PR — deferred intentionally.
