### PR TITLE
Fix find_visas() crash when a VISA backend is unavailable

### DIFF
--- a/rigol_ds1000z/utils.py
+++ b/rigol_ds1000z/utils.py
@@ -19,14 +19,20 @@ def find_visas():
     for visa_backend in ["@ivi", "@py"]:
         try:
             visa_manager = ResourceManager(visa_backend)
-        except LibraryError:
-            pass
+        except (LibraryError, OSError, ValueError):
+            # The backend is unavailable (e.g. no NI-VISA library installed for
+            # "@ivi", which raises a plain OSError rather than a LibraryError);
+            # skip it instead of letting the error propagate.
+            continue
 
         for visa_name in visa_manager.list_resources():
             try:
                 visa_resource = visa_manager.open_resource(visa_name)
-                match = search(RIGOL_IDN_REGEX, visa_resource.query("*IDN?"))
-                if match:
+            except VisaIOError:
+                continue
+
+            try:
+                if search(RIGOL_IDN_REGEX, visa_resource.query("*IDN?")):
                     visas.append((visa_name, visa_backend))
             except VisaIOError:
                 pass

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,46 @@
 import os
 
+import rigol_ds1000z.utils as utils
 from rigol_ds1000z import Rigol_DS1000Z, process_display, process_waveform
+
+
+class _FakeResource:
+    def __init__(self, idn):
+        self._idn = idn
+
+    def query(self, _cmd):
+        return self._idn
+
+    def close(self):
+        pass
+
+
+class _FakeManager:
+    def __init__(self, resources):
+        self._resources = resources
+
+    def list_resources(self):
+        return tuple(self._resources)
+
+    def open_resource(self, name):
+        return self._resources[name]
+
+
+def test_find_visas_skips_unavailable_backend(monkeypatch):
+    # No NI-VISA installed makes ResourceManager("@ivi") raise a plain OSError;
+    # find_visas should skip that backend and still discover via "@py" instead
+    # of letting the error propagate.
+    rigol_idn = "RIGOL TECHNOLOGIES,DS1104Z,DS1ZA00000000,00.04.05"
+    resource = "TCPIP::192.168.0.2::INSTR"
+
+    def fake_resource_manager(backend):
+        if backend == "@ivi":
+            raise OSError("Could not open VISA library")
+        return _FakeManager({resource: _FakeResource(rigol_idn)})
+
+    monkeypatch.setattr(utils, "ResourceManager", fake_resource_manager)
+
+    assert utils.find_visas() == [(resource, "@py")]
 
 
 def test_process_display():


### PR DESCRIPTION
## Summary

Fixes a crash in `find_visas()` when a VISA backend is unavailable.

`find_visas()` iterates the `@ivi` and `@py` backends, but only caught `LibraryError` when constructing the `ResourceManager`. On a host **without an NI-VISA library installed**, `ResourceManager("@ivi")` raises a plain `OSError` (`Could not open VISA library`), which escaped the handler and crashed discovery before `@py` was ever tried — so the library could not connect on any machine lacking NI-VISA (e.g. a Mac talking to a LAN scope via PyVISA-py).

### Changes
- Catch `(LibraryError, OSError, ValueError)` and `continue` to the next backend, instead of `pass` (which fell through to use an unbound/stale `visa_manager`).
- Move `open_resource()` into its own `try`/`continue` so the `finally: visa_resource.close()` only runs when the resource actually opened — the previous code could reference an unbound name there if `open_resource` raised.

## Testing

Adds `tests/test_utils.py::test_find_visas_skips_unavailable_backend` — a **hardware-free** unit test (monkeypatches `ResourceManager` so `@ivi` raises `OSError` and `@py` yields a Rigol resource) asserting the bad backend is skipped and discovery still succeeds. Runs anywhere, no instrument required.

Also verified manually on a host with no NI-VISA: `find_visas()` now returns `[]` instead of raising.
