### PR TITLE
Add MEASure subsystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ The software does insert some sleep time on specific commands (such as reset and
 | LAN | no |
 | MATH | no |
 | MASK | no |
-| MEASure | no |
+| MEASure | YES |
 | REFerence | no |
 | STORage | no |
 | SYSTem | no |

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -13,6 +13,7 @@ Click the links below or in the sidebar to see how the available functional inte
    channel.rst
    timebase.rst
    trigger.rst
+   measure.rst
    display.rst
    waveform.rst
    ieee.rst

--- a/docs/source/measure.rst
+++ b/docs/source/measure.rst
@@ -1,0 +1,5 @@
+Measure
+=======
+
+.. automodule:: src.measure
+	:members: measure

--- a/rigol_ds1000z/src/measure.py
+++ b/rigol_ds1000z/src/measure.py
@@ -1,0 +1,100 @@
+from collections import namedtuple
+from time import sleep
+from typing import Optional, Union
+
+MEASURE = namedtuple("MEASURE", "source counter item value statistics")
+STATISTICS = namedtuple("STATISTICS", "maximum minimum current average deviation")
+
+# Measurement item mnemonics accepted by ``item`` (DS1000Z programming guide).
+ITEMS = (
+    "VMAX", "VMIN", "VPP", "VTOP", "VBASe", "VAMP", "VAVG", "VRMS",
+    "OVERshoot", "PREShoot", "MARea", "MPARea", "PERiod", "FREQuency",
+    "RTIMe", "FTIMe", "PWIDth", "NWIDth", "PDUTy", "NDUTy", "TVMAX", "TVMIN",
+    "PSLEWrate", "NSLEWrate", "VUPper", "VMID", "VLOWer", "VARIance",
+    "PVRMs", "PPULses", "NPULses", "PEDGes", "NEDGes",
+)  # fmt: skip
+
+
+def _source_token(source):
+    """Format a channel source as either ``CHAN<n>`` (int) or a literal (str)."""
+    return source if isinstance(source, str) else "CHAN{:d}".format(source)
+
+
+def measure(
+    oscope,
+    source: Union[int, str, None] = None,
+    counter: Union[int, str, None] = None,
+    item: Optional[str] = None,
+    clear: Optional[str] = None,
+    statistics: Optional[bool] = None,
+):
+    """
+    Send commands to make automatic measurements on an oscilloscope.
+    All arguments are optional. The ``source`` is the default channel used for
+    item measurements; an ``item`` query returns its measured ``value`` against
+    that source. See ``measure.ITEMS`` for the supported item mnemonics
+    (e.g. ``VPP``, ``VAVG``, ``FREQuency``, ``PERiod``, ``PWIDth``).
+
+    Args:
+        source (int, str): ``:MEASure:SOURce`` (a channel number or ``MATH``).
+        counter (int, str): ``:MEASure:COUNter:SOURce`` (a channel or ``OFF``);
+            setting it is followed by a 1s delay so the counter can gate.
+        item (str): The measurement item to query via ``:MEASure:ITEM?``.
+        clear (str): ``:MEASure:CLEar`` (``ITEM1`` through ``ITEM5`` or ``ALL``).
+        statistics (bool): When ``True`` and an ``item`` is given, enable the
+            statistics display (``:MEASure:STATistic:DISPlay``) and report the
+            item's statistics.
+
+    Returns:
+        A namedtuple with fields ``source``, ``counter``, ``item``, ``value``,
+        and ``statistics``. ``source`` and ``counter`` are always queried.
+        ``counter`` is the frequency counter value (``:MEASure:COUNter:VALue?``)
+        or ``None`` when the counter source is ``OFF``. ``item`` echoes the
+        queried item and ``value`` is its float result, both ``None`` when no
+        ``item`` was given. ``statistics`` is a ``STATISTICS`` namedtuple
+        (``maximum``, ``minimum``, ``current``, ``average``, ``deviation``)
+        when requested, otherwise ``None``.
+    """
+    if source is not None:
+        oscope.write(":MEAS:SOUR " + _source_token(source))
+
+    if counter is not None:
+        oscope.write(":MEAS:COUN:SOUR " + _source_token(counter))
+        sleep(1)  # allow the frequency counter to gate before its value is read
+
+    if clear is not None:
+        oscope.write(":MEAS:CLE " + clear)
+
+    source_query = oscope.query(":MEAS:SOUR?")
+    if source_query.startswith("CHAN"):
+        source_query = int(source_query[-1])
+
+    counter_source = oscope.query(":MEAS:COUN:SOUR?")
+    counter_value = (
+        None if counter_source == "OFF" else float(oscope.query(":MEAS:COUN:VAL?"))
+    )
+
+    value = None
+    statistics_query = None
+    if item is not None:
+        src = _source_token(source_query)
+        value = float(oscope.query(":MEAS:ITEM? {:s},{:s}".format(item, src)))
+
+        if statistics:
+            oscope.write(":MEAS:STAT:DISP 1")
+            oscope.write(":MEAS:STAT:ITEM {:s},{:s}".format(item, src))
+            statistics_query = STATISTICS(
+                maximum=float(oscope.query(":MEAS:STAT:ITEM? MAX,{:s}".format(item))),
+                minimum=float(oscope.query(":MEAS:STAT:ITEM? MIN,{:s}".format(item))),
+                current=float(oscope.query(":MEAS:STAT:ITEM? CURR,{:s}".format(item))),
+                average=float(oscope.query(":MEAS:STAT:ITEM? AVER,{:s}".format(item))),
+                deviation=float(oscope.query(":MEAS:STAT:ITEM? DEV,{:s}".format(item))),
+            )
+
+    return MEASURE(
+        source=source_query,
+        counter=counter_value,
+        item=item,
+        value=value,
+        statistics=statistics_query,
+    )

--- a/rigol_ds1000z/src/oscope.py
+++ b/rigol_ds1000z/src/oscope.py
@@ -7,6 +7,7 @@ from pyvisa import ResourceManager
 from rigol_ds1000z.src.channel import channel
 from rigol_ds1000z.src.display import display
 from rigol_ds1000z.src.ieee import ieee
+from rigol_ds1000z.src.measure import measure
 from rigol_ds1000z.src.timebase import timebase
 from rigol_ds1000z.src.trigger import trigger
 from rigol_ds1000z.src.waveform import waveform
@@ -17,8 +18,8 @@ class Rigol_DS1000Z:
     """
     A class for communicating with a Rigol DS1000Z series oscilloscope.
     This class is compatible with context managers. The functional interfaces
-    ``ieee``, ``channel``, ``timebase``, ``display``, ``waveform``, and ``trigger``
-    are bound to this object as partial functions.
+    ``ieee``, ``channel``, ``timebase``, ``display``, ``waveform``, ``trigger``,
+    and ``measure`` are bound to this object as partial functions.
 
     Args:
         visa (str): The VISA resource address string.
@@ -41,6 +42,7 @@ class Rigol_DS1000Z:
         self.display = partial(display, self)
         self.waveform = partial(waveform, self)
         self.trigger = partial(trigger, self)
+        self.measure = partial(measure, self)
 
     def __enter__(self):
         return self.open()

--- a/tests/test_measure.py
+++ b/tests/test_measure.py
@@ -1,0 +1,42 @@
+from pytest import approx, fixture
+
+from rigol_ds1000z import Rigol_DS1000Z
+
+
+@fixture(scope="function")
+def oscope():
+    with Rigol_DS1000Z() as oscope:
+        oscope.ieee(rst=True)
+        yield oscope
+
+
+def test_source(oscope):
+    assert oscope.measure(source=2).source == 2
+    assert oscope.measure(source="MATH").source == "MATH"
+
+
+def test_item(oscope):
+    oscope.autoscale()
+
+    measure = oscope.measure(source=2, item="VPP")
+    assert measure.item == "VPP"
+    assert measure.value == approx(3.0, rel=0.2)  # calibration square wave ~3 Vpp
+
+
+def test_frequency(oscope):
+    oscope.autoscale()
+    assert oscope.measure(source=2, item="FREQ").value == approx(1e3, rel=0.2)
+
+
+def test_counter(oscope):
+    oscope.autoscale()
+    assert oscope.measure(counter=2).counter == approx(1e3, rel=0.2)
+    assert oscope.measure(counter="OFF").counter is None
+
+
+def test_statistics(oscope):
+    oscope.autoscale()
+
+    measure = oscope.measure(source=2, item="VPP", statistics=True)
+    assert measure.statistics is not None
+    assert measure.statistics.current == approx(measure.value, rel=0.2)


### PR DESCRIPTION
Adds the MEASure subsystem with support for all standard measurement parameters. Targets the same interface pattern as the existing trigger and channel subsystems.